### PR TITLE
Code cleanup, higher efficiency, database resource reduction/conservation

### DIFF
--- a/PubMedDB.py
+++ b/PubMedDB.py
@@ -716,12 +716,12 @@ class SupplMeshName(Base):
 #    session.close()
 
 
-def init(db):
+def init(db_name):
     """
         initialize the database and return the db_engine and the Base-Class for further usage
         an already existing DB want be overridden, you still get the handle (engine) to the DB
     """
-    connection_string = 'postgresql://parser:parser@localhost/%s' % (db,)
+    connection_string = 'postgresql://parser:parser@localhost/%s' % (db_name,)
 
     # Postgres default is max 100 connections
     new_engine = create_engine(connection_string, pool_size=20, max_overflow=10)

--- a/PubMedDB.py
+++ b/PubMedDB.py
@@ -74,7 +74,7 @@ class Citation(Base):
         CheckConstraint("article_author_list_comp_yn IN ('Y', 'N', 'y', 'n')", name='ck4_medline_citation'),
         CheckConstraint("data_bank_list_complete_yn IN ('Y', 'N', 'y', 'n')", name='ck5_medline_citation'),
         CheckConstraint("grant_list_complete_yn IN ('Y', 'N', 'y', 'n')", name='ck6_medline_citation'),
-        {'schema': SCHEMA} 
+        {'schema': SCHEMA}
     )
 
 
@@ -97,7 +97,7 @@ class PMID_File_Mapping(Base):
         ForeignKeyConstraint(['id_file','xml_file_name'], [SCHEMA+'.tbl_xml_file.id',SCHEMA+'.tbl_xml_file.xml_file_name'], onupdate="CASCADE", ondelete="CASCADE", name='fk3_pmids_in_file'),
         ForeignKeyConstraint(['fk_pmid'], [SCHEMA+'.tbl_medline_citation.pmid'], onupdate="CASCADE", ondelete="CASCADE", name="fk2_pmids_in_file"),
         PrimaryKeyConstraint( 'fk_pmid'),
-        {'schema': SCHEMA} 
+        {'schema': SCHEMA}
     )
 
 
@@ -125,7 +125,7 @@ class XMLFile(Base):
 
     __table_args__  = (
         PrimaryKeyConstraint('id','xml_file_name'),
-        {'schema': SCHEMA} 
+        {'schema': SCHEMA}
     )
 
 
@@ -715,26 +715,28 @@ class SupplMeshName(Base):
 #    session.commit()
 #    session.close()
 
+
 def init(db):
     """
         initialize the database and return the db_engine and the Base-Class for further usage
         an already existing DB want be overridden, you still get the handle (engine) to the DB
     """
-    con = 'postgresql://parser:parser@localhost/'+db
-    engine = create_engine(con)
-    Base.metadata.create_all(engine)
+    connection_string = 'postgresql://parser:parser@localhost/%s' % (db,)
 
-    return engine, Base
+    # Postgres default is max 100 connections
+    new_engine = create_engine(connection_string, pool_size=20, max_overflow=10)
+    Base.metadata.create_all(new_engine)
 
-def create_tables(db):
+    return new_engine, Base
+
+
+def create_tables(db_engine):
     """
         reset the whole DB
     """
-    con = 'postgresql://parser:parser@localhost/'+db
-    engine, Base = init(db)
     try:
-        Base.metadata.drop_all(engine)
-        Base.metadata.create_all(engine)
+        Base.metadata.drop_all(db_engine)
+        Base.metadata.create_all(db_engine)
 
     except:
         print "Can't create table"

--- a/PubMedParser.py
+++ b/PubMedParser.py
@@ -13,15 +13,13 @@ import sys, os
 import xml.etree.cElementTree as etree
 import datetime
 import warnings
-import logging
 import time
 
 import PubMedDB
 from sqlalchemy.orm import *
-from sqlalchemy import *
 from sqlalchemy.exc import *
 import gzip
-from multiprocessing import Pool, Value
+from multiprocessing import Pool
 
 
 WARNING_LEVEL = "always"  # error, ignore, always, default, module, once
@@ -47,8 +45,6 @@ class FilePreloadScreener:
     def __exit__(self, exc_type, exc_value, traceback):
         self.session.flush()
         self.session.close()
-        # TODO don't just close the session, close the CONNECTION!
-        # TODO docs say this should release connection resources, why isn't it?
 
     @staticmethod
     def _trim_to_invariant_path(path):
@@ -738,7 +734,7 @@ if __name__ == "__main__":
                       help="All queued files are passed if no start and end parameter is set. Otherwise you can specify a start and end o the queue. For example to split the parsing on several machines.")
     parser.add_option("-i", "--input", dest="medline_path",
                       default='data/pancreatic_cancer/',
-                      help="specify the path to the medine XML-Files (default: data/pancreatic_cancer/)")
+                      help="specify the path to the medline XML-Files (default: data/pancreatic_cancer/)")
     parser.add_option("-p", "--processes",
                       dest="PROCESSES", default=2,
                       help="How many processes should be used. (Default: 2)")


### PR DESCRIPTION
* Check database before restart and exclude completely parsed files
* Commit immediately, so rollback doesn't lose more than one article
* Efficiently conserve connections during multi-processing by closing sessions and connections
* Use a shared connection pool for non-multi-processing
* Don't use multi-processing for singular exection
* Common truncation function
* Use ellipsis symbol to save space, hold 2 more chars from long string
* Store initials in lowercase for easy comparision
* Only fetch single ID, not whole object graph to confirm uniqueness
* Code cleanup to comply with PEP-8
